### PR TITLE
Limit autocomplete

### DIFF
--- a/lib/golo-ide.js
+++ b/lib/golo-ide.js
@@ -100,6 +100,12 @@ class GoloCodeProvider {
 
   getSuggestions({activatedManually, bufferPosition, editor, prefix, scopeDescriptor}) {
     // 🛠 WIP
+    regex = /[a-zA-Z]+$/
+
+    if(activatedManually || prefix.match(regex))
+        return getSnippets();
+    else
+        return [];
     return getSnippets();
   }
 

--- a/settings/language-golo.cson
+++ b/settings/language-golo.cson
@@ -1,0 +1,4 @@
+'.source.golo':
+  'editor':
+    'commentStart': '----',
+    'commentEnd': '----'

--- a/settings/language-golo.cson
+++ b/settings/language-golo.cson
@@ -1,4 +1,3 @@
 '.source.golo':
   'editor':
-    'commentStart': '----',
-    'commentEnd': '----'
+    'commentStart': '# '


### PR DESCRIPTION
When writing golo code, autocomplete is too much present. When typing a parenthesis, a number or just a space, it proposes all the golo language, resulting in the insertion of unwanted instructions. In this modification, i added a filter to have only letters in the prefix (except if manually asked).
